### PR TITLE
enabling scaling of Tk frame

### DIFF
--- a/Dans_Diffraction/tkgui/diffractometer.py
+++ b/Dans_Diffraction/tkgui/diffractometer.py
@@ -1454,6 +1454,12 @@ class DiffractometerGui:
         # --- Scan ---
         tk_scan(bottom_left, angle_dict, self.latt, self.det)
 
+        # Configure expansion of Tk frame
+        self.root.columnconfigure(1, weight=1)
+        self.root.columnconfigure(2, weight=1)
+        self.root.rowconfigure(1, weight=3)
+        self.root.rowconfigure(2, weight=1)
+
         self.latt.generate_refs()
         self.det.generate_detector()
 


### PR DESCRIPTION
Dear Dan

Now trying out the diffractometer GUI the size of the matplotlib figures is rather small on a high DPI monitor (on Windows). I don't know if the scaling works better on other systems. The DPI option in the menu unfortunately does not really help here because it changes the DPI of the figure but not its physical size. Resizing the whole window is possible but does not enlarge the figures.


![image](https://github.com/DanPorter/Dans_Diffraction/assets/5851636/815c4d53-24fe-4a1c-ab36-2984b2fc08c9)

I found a small option in tk to ensure that the panel scales when the window is enlarged.

This allows to use for example 90 DPI easily:
![image](https://github.com/DanPorter/Dans_Diffraction/assets/5851636/b8557674-074c-42da-a9f5-135feef4900b)

Here is a small patch that enables this functionality. Is that an OK solution?

